### PR TITLE
[BM-2] 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+.idea/**
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### .secret
+application-user-secret.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/user-0.0.1-SNAPSHOT.jar user.jar
+ENV SPRING_PROFILES_ACTIVE=dev
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "user.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,31 @@ repositories {
 
 dependencies {
 
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // Spring Cloud Config
     implementation("org.springframework.cloud:spring-cloud-starter-config:4.2.1")
 
     // Spring Cloud Eureka Client
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:4.2.1")
+
+    // Jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.4.4")
+
+    // Mysql
+    implementation("com.mysql:mysql-connector-j:9.2.0")
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  mysql:
+    container_name: mysql-bmUser
+    image: mysql:9.2
+    environment:
+      - MYSQL_DATABASE=bmUser
+      - MYSQL_ROOT_PASSWORD=test
+      - TZ=Asia/Seoul
+    ports:
+      - "3306:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+

--- a/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.bidmall.user.adapter.in.web.controller;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.adapter.in.web.mapper.UserWebMapper;
+import com.bidmall.user.application.port.in.UserUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserWebMapper userMapper;
+  private final UserUseCase userUseCase;
+
+  @PostMapping("/login")
+  public LoginResponse login(@RequestBody LoginRequest loginRequest) {
+    LoginCommand loginCommand = userMapper.loginToCommand(loginRequest);
+    return userUseCase.login(loginCommand);
+  }
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/command/LoginCommand.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/command/LoginCommand.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginCommand {
+
+  private String account;
+  private String password;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/request/LoginRequest.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginRequest {
+
+  private String account;
+  private String password;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/response/LoginResponse.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/response/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+
+  private String accessToken;
+  private String refreshToken;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.in.web.mapper;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserWebMapper {
+  LoginCommand loginToCommand(LoginRequest loginRequest);
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.bidmall.user.adapter.out.persistence.adapter;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.manager.UserEntityReader;
+import com.bidmall.user.adapter.out.persistence.mapper.UserPersistenceMapper;
+import com.bidmall.user.application.port.out.UserRepositoryPort;
+import com.bidmall.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepositoryPort {
+
+  private final UserEntityReader userEntityReader;
+  private final UserPersistenceMapper userMapper;
+
+  @Override
+  public User findByAccountAndPassword(String account, String password) {
+    UserEntity entity = userEntityReader.findByAccountAndPassword(account, password);
+    return userMapper.entityToDomain(entity);
+  }
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
@@ -1,0 +1,25 @@
+package com.bidmall.user.adapter.out.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "users")
+public class UserEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String account;
+
+  private String password;
+
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
@@ -1,0 +1,20 @@
+package com.bidmall.user.adapter.out.persistence.manager;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.repository.UserJpaRepository;
+import com.bidmall.user.exception.InvalidCredentialsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEntityReader {
+
+  private final UserJpaRepository userJpaRepository;
+
+  public UserEntity findByAccountAndPassword(String account, String password) {
+    return userJpaRepository.findByAccountAndPassword(account, password)
+        .orElseThrow(InvalidCredentialsException::new);
+  }
+
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.out.persistence.mapper;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.domain.model.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserPersistenceMapper {
+  User entityToDomain(UserEntity userEntity);
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.out.persistence.repository;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+  Optional<UserEntity> findByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/bidmall/user/application/auth/TokenManager.java
+++ b/src/main/java/com/bidmall/user/application/auth/TokenManager.java
@@ -1,0 +1,16 @@
+package com.bidmall.user.application.auth;
+
+import com.bidmall.user.domain.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenManager {
+
+  // note. 임시 코드 / 이후 삭제 및 변경 예정
+  public TokenResponse getToken(User user) {
+    return TokenResponse.builder()
+        .accessToken(user.getName())
+        .refreshToken(user.getName())
+        .build();
+  }
+}

--- a/src/main/java/com/bidmall/user/application/auth/TokenResponse.java
+++ b/src/main/java/com/bidmall/user/application/auth/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.application.auth;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+  private String accessToken;
+  private String refreshToken;
+
+}

--- a/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
+++ b/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
@@ -1,0 +1,12 @@
+package com.bidmall.user.application.mapper;
+
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.application.auth.TokenResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserApplicationMapper {
+
+  LoginResponse tokenResponseToLogin(TokenResponse tokenResponse);
+
+}

--- a/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
@@ -1,0 +1,12 @@
+package com.bidmall.user.application.port.in;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface UserUseCase {
+
+  LoginResponse login(LoginCommand loginCommand);
+
+}

--- a/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
@@ -1,0 +1,7 @@
+package com.bidmall.user.application.port.out;
+
+import com.bidmall.user.domain.model.User;
+
+public interface UserRepositoryPort {
+  User findByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/bidmall/user/application/service/UserService.java
+++ b/src/main/java/com/bidmall/user/application/service/UserService.java
@@ -1,0 +1,34 @@
+package com.bidmall.user.application.service;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.application.auth.TokenManager;
+import com.bidmall.user.application.auth.TokenResponse;
+import com.bidmall.user.application.mapper.UserApplicationMapper;
+import com.bidmall.user.application.port.in.UserUseCase;
+import com.bidmall.user.application.port.out.UserRepositoryPort;
+import com.bidmall.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserUseCase {
+
+  private final UserRepositoryPort userRepositoryPort;
+  private final UserApplicationMapper userMapper;
+  private final TokenManager tokenManager;
+
+  @Override
+  public LoginResponse login(LoginCommand loginCommand) {
+
+    String account = loginCommand.getAccount();
+    String password = loginCommand.getPassword();
+    User user = userRepositoryPort.findByAccountAndPassword(account, password);
+
+    TokenResponse response = tokenManager.getToken(user);
+
+    return userMapper.tokenResponseToLogin(response);
+  }
+
+}

--- a/src/main/java/com/bidmall/user/domain/model/User.java
+++ b/src/main/java/com/bidmall/user/domain/model/User.java
@@ -1,0 +1,18 @@
+package com.bidmall.user.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class User {
+
+  private Long id;
+
+  private String account;
+
+  private String password;
+
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/exception/ErrorType.java
+++ b/src/main/java/com/bidmall/user/exception/ErrorType.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorType {
+  INVALID_CREDENTIALS("ID 혹은 PW가 잘못되었습니다.");
+
+  private final String message;
+
+  ErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/bidmall/user/exception/InvalidCredentialsException.java
@@ -1,0 +1,18 @@
+package com.bidmall.user.exception;
+
+import com.bidmall.user.exception.type.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class InvalidCredentialsException extends BusinessException {
+
+  private final String code;
+  public InvalidCredentialsException() {
+    this(ErrorType.INVALID_CREDENTIALS.getMessage());
+  }
+
+  public InvalidCredentialsException(final String message) {
+    super(message);
+    this.code = ErrorType.INVALID_CREDENTIALS.name();
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/type/ApiErrorType.java
+++ b/src/main/java/com/bidmall/user/exception/type/ApiErrorType.java
@@ -1,0 +1,15 @@
+package com.bidmall.user.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ApiErrorType {
+
+  BAD_REQUEST("잘못된 요청입니다.");
+
+  private final String message;
+
+  ApiErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/type/BusinessException.java
+++ b/src/main/java/com/bidmall/user/exception/type/BusinessException.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final String code;
+
+  public BusinessException(final String message) {
+    super(message);
+    this.code = ApiErrorType.BAD_REQUEST.name();
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,26 @@
+spring:
+  application:
+    name: user
+  cloud:
+    config:
+      enabled: false
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/bmUser
+    username: root
+    password: test
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   config:
     import: classpath:application-user-secret.yml
   profiles:
-    active: prod
+    active: local


### PR DESCRIPTION
기본적인 로그인 구현하였습니다.

패키지 구조는 해당 [블로그](https://curiousjinan.tistory.com/entry/spring-hexagonal-architecture)를 참고하여 구성하였습니다. 
특이사항으로 persistence 단의 Repository -> adapter 과정 중, 예외처리를 위해 manager 패키지의 Redaer 클래스를 생성하였습니다.

이는 Jpa 에서 엔티티 객체를 Optional 로 가져와 안전하게 처리하며, 예외 처리 및 가공을 위한 클래스입니다.

기존에는 Repository 에서 엔티티 객체를 반환, adapter 에서 이를 도메인으로 매핑하는 과정을 가졌습니다만, Jpa 에서 Optional 을 사용하지 않고 객체를 가져오는 것은 위험하다 판단하여 Repository 에서는 Optional을 반환하도록 하였고, adapter Optional 에 대한 예외 처리를 진행하는 것은 adapter 의 역할을 벗어나는 로직이라 생각하였기에 별도로 생성하였습니다.

때문에 이후 adapter 에서는 Repository 를 직접 참조하지 않고, manager 패키지를 거쳐 참조하도록 구현할 필요가 있어보입니다.

추가적으로, 로그인 관련해 JWT, 세션 등 기술이 확정되지 않음에 따라 임시 로직을 작성하였고 이후 수정/제거 예정입니다.


---

해당 작업에서 아래와 같은 의존성이 추가되었습니다.
2025.04.03 작업 날짜 기준 최신 버전으로 설정하였습니다.

- SpringWeb
- Jpa (3.4.4)
- Mysql (9.2.0
- Lombok (1.18.38)
- MapStruct (1.6.3)
- Swagger (2.8.6)