### PR TITLE
[BM-5] 회원 탈퇴

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+.idea/**
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### .secret
+application-user-secret.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/user-0.0.1-SNAPSHOT.jar user.jar
+ENV SPRING_PROFILES_ACTIVE=dev
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "user.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,31 @@ repositories {
 
 dependencies {
 
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // Spring Cloud Config
     implementation("org.springframework.cloud:spring-cloud-starter-config:4.2.1")
 
     // Spring Cloud Eureka Client
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:4.2.1")
+
+    // Jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.4.4")
+
+    // Mysql
+    implementation("com.mysql:mysql-connector-j:9.2.0")
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  mysql:
+    container_name: mysql-bmUser
+    image: mysql:9.2
+    environment:
+      - MYSQL_DATABASE=bmUser
+      - MYSQL_ROOT_PASSWORD=test
+      - TZ=Asia/Seoul
+    ports:
+      - "3306:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+

--- a/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.bidmall.user.adapter.in.web.controller;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.adapter.in.web.mapper.UserWebMapper;
+import com.bidmall.user.application.port.in.UserUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserWebMapper userMapper;
+  private final UserUseCase userUseCase;
+
+  @PostMapping("/login")
+  public LoginResponse login(@RequestBody LoginRequest loginRequest) {
+    LoginCommand loginCommand = userMapper.loginToCommand(loginRequest);
+    return userUseCase.login(loginCommand);
+  }
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
@@ -8,6 +8,8 @@ import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
 import com.bidmall.user.adapter.in.web.mapper.UserWebMapper;
 import com.bidmall.user.application.port.in.UserUseCase;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +33,13 @@ public class UserController {
   public void signUp(@RequestBody SignUpRequest signUpRequest) {
     SignUpCommand signUpCommand = userMapper.signUpToCommand(signUpRequest);
     userUseCase.signUp(signUpCommand);
+  }
+
+  @DeleteMapping()
+  public void deleteUser() {
+    // note. 현재 사용자의 정보를 가져오는 코드 필요 / 현재 임의 지정
+    Long userId = 1L;
+    userUseCase.delete(userId);
+
   }
 }

--- a/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.bidmall.user.adapter.in.web.controller;
 
 import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.command.SignUpCommand;
 import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import com.bidmall.user.adapter.in.web.dto.request.SignUpRequest;
 import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
 import com.bidmall.user.adapter.in.web.mapper.UserWebMapper;
 import com.bidmall.user.application.port.in.UserUseCase;
@@ -23,5 +25,11 @@ public class UserController {
   public LoginResponse login(@RequestBody LoginRequest loginRequest) {
     LoginCommand loginCommand = userMapper.loginToCommand(loginRequest);
     return userUseCase.login(loginCommand);
+  }
+
+  @PostMapping("/signUp")
+  public void signUp(@RequestBody SignUpRequest signUpRequest) {
+    SignUpCommand signUpCommand = userMapper.signUpToCommand(signUpRequest);
+    userUseCase.signUp(signUpCommand);
   }
 }

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/command/LoginCommand.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/command/LoginCommand.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginCommand {
+
+  private String account;
+  private String password;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/command/SignUpCommand.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/command/SignUpCommand.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.adapter.in.web.dto.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignUpCommand {
+
+  private String account;
+  private String password;
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/request/LoginRequest.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginRequest {
+
+  private String account;
+  private String password;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/request/SignUpRequest.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/request/SignUpRequest.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.adapter.in.web.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignUpRequest {
+
+  private String account;
+  private String password;
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/dto/response/LoginResponse.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/dto/response/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.bidmall.user.adapter.in.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+
+  private String accessToken;
+  private String refreshToken;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.in.web.mapper;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserWebMapper {
+  LoginCommand loginToCommand(LoginRequest loginRequest);
+}

--- a/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/in/web/mapper/UserWebMapper.java
@@ -1,10 +1,17 @@
 package com.bidmall.user.adapter.in.web.mapper;
 
 import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.command.SignUpCommand;
 import com.bidmall.user.adapter.in.web.dto.request.LoginRequest;
+import com.bidmall.user.adapter.in.web.dto.request.SignUpRequest;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserWebMapper {
+
+  // 로그인
   LoginCommand loginToCommand(LoginRequest loginRequest);
+
+  // 회원가입
+  SignUpCommand signUpToCommand(SignUpRequest signUpRequest);
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.bidmall.user.adapter.out.persistence.adapter;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.manager.UserEntityReader;
+import com.bidmall.user.adapter.out.persistence.mapper.UserPersistenceMapper;
+import com.bidmall.user.application.port.out.UserRepositoryPort;
+import com.bidmall.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepositoryPort {
+
+  private final UserEntityReader userEntityReader;
+  private final UserPersistenceMapper userMapper;
+
+  @Override
+  public User findByAccountAndPassword(String account, String password) {
+    UserEntity entity = userEntityReader.findByAccountAndPassword(account, password);
+    return userMapper.entityToDomain(entity);
+  }
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
@@ -18,8 +18,8 @@ public class UserRepositoryAdapter implements UserRepositoryPort {
   private final UserPersistenceMapper userMapper;
 
   @Override
-  public User findByAccountAndPassword(String account, String password) {
-    UserEntity entity = userEntityReader.findByAccountAndPassword(account, password);
+  public User findActiveUserByAccountAndPassword(String account, String password) {
+    UserEntity entity = userEntityReader.findActiveUserByAccountAndPassword(account, password);
     return userMapper.entityToDomain(entity);
   }
 

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
@@ -28,4 +28,10 @@ public class UserRepositoryAdapter implements UserRepositoryPort {
     UserEntity entity = userMapper.domainToEntity(user);
     userEntityCreator.save(entity);
   }
+
+  @Override
+  public User findById(Long id) {
+    UserEntity entity = userEntityReader.findById(id);
+    return userMapper.entityToDomain(entity);
+  }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/adapter/UserRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.bidmall.user.adapter.out.persistence.adapter;
 
 import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.manager.UserEntityCreator;
 import com.bidmall.user.adapter.out.persistence.manager.UserEntityReader;
 import com.bidmall.user.adapter.out.persistence.mapper.UserPersistenceMapper;
 import com.bidmall.user.application.port.out.UserRepositoryPort;
@@ -13,11 +14,18 @@ import org.springframework.stereotype.Component;
 public class UserRepositoryAdapter implements UserRepositoryPort {
 
   private final UserEntityReader userEntityReader;
+  private final UserEntityCreator userEntityCreator;
   private final UserPersistenceMapper userMapper;
 
   @Override
   public User findByAccountAndPassword(String account, String password) {
     UserEntity entity = userEntityReader.findByAccountAndPassword(account, password);
     return userMapper.entityToDomain(entity);
+  }
+
+  @Override
+  public void save(User user) {
+    UserEntity entity = userMapper.domainToEntity(user);
+    userEntityCreator.save(entity);
   }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
@@ -1,0 +1,25 @@
+package com.bidmall.user.adapter.out.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "users")
+public class UserEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String account;
+
+  private String password;
+
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
@@ -33,10 +33,17 @@ public class UserEntity {
   @NotNull
   private String name;
 
+  @Column(nullable = false)
+  @NotNull
+  private boolean isDeleted;
+
+
+
   @Builder
   public UserEntity(String account, String password, String name) {
     this.account = account;
     this.password = password;
     this.name = name;
+    this.isDeleted = false;
   }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
@@ -1,25 +1,42 @@
 package com.bidmall.user.adapter.out.persistence.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "users")
+@NoArgsConstructor
 public class UserEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
+  @NotNull
   private String account;
 
+  @Column(nullable = false)
+  @NotNull
   private String password;
 
+  @Column(nullable = false)
+  @NotNull
   private String name;
 
+  @Builder
+  public UserEntity(String account, String password, String name) {
+    this.account = account;
+    this.password = password;
+    this.name = name;
+  }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/entity/UserEntity.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +16,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "users")
-@NoArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
 
   @Id
@@ -35,15 +39,6 @@ public class UserEntity {
 
   @Column(nullable = false)
   @NotNull
-  private boolean isDeleted;
+  private boolean deleted;
 
-
-
-  @Builder
-  public UserEntity(String account, String password, String name) {
-    this.account = account;
-    this.password = password;
-    this.name = name;
-    this.isDeleted = false;
-  }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityCreator.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityCreator.java
@@ -1,0 +1,17 @@
+package com.bidmall.user.adapter.out.persistence.manager;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEntityCreator {
+
+  private final UserJpaRepository userJpaRepository;
+
+  public UserEntity save(UserEntity userEntity) {
+    return userJpaRepository.save(userEntity);
+  }
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
@@ -1,0 +1,20 @@
+package com.bidmall.user.adapter.out.persistence.manager;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.adapter.out.persistence.repository.UserJpaRepository;
+import com.bidmall.user.exception.InvalidCredentialsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEntityReader {
+
+  private final UserJpaRepository userJpaRepository;
+
+  public UserEntity findByAccountAndPassword(String account, String password) {
+    return userJpaRepository.findByAccountAndPassword(account, password)
+        .orElseThrow(InvalidCredentialsException::new);
+  }
+
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
@@ -3,6 +3,8 @@ package com.bidmall.user.adapter.out.persistence.manager;
 import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
 import com.bidmall.user.adapter.out.persistence.repository.UserJpaRepository;
 import com.bidmall.user.exception.InvalidCredentialsException;
+import com.bidmall.user.exception.NotFoundUserException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +15,11 @@ public class UserEntityReader {
   private final UserJpaRepository userJpaRepository;
 
   public UserEntity findActiveUserByAccountAndPassword(String account, String password) {
-    return userJpaRepository.findByAccountAndPasswordAndIsDeleted(account, password, false)
+    return userJpaRepository.findByAccountAndPasswordAndDeleted(account, password, false)
         .orElseThrow(InvalidCredentialsException::new);
   }
 
+  public UserEntity findById(Long id) {
+    return userJpaRepository.findById(id).orElseThrow(NotFoundUserException::new);
+  }
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/manager/UserEntityReader.java
@@ -12,8 +12,8 @@ public class UserEntityReader {
 
   private final UserJpaRepository userJpaRepository;
 
-  public UserEntity findByAccountAndPassword(String account, String password) {
-    return userJpaRepository.findByAccountAndPassword(account, password)
+  public UserEntity findActiveUserByAccountAndPassword(String account, String password) {
+    return userJpaRepository.findByAccountAndPasswordAndIsDeleted(account, password, false)
         .orElseThrow(InvalidCredentialsException::new);
   }
 

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.out.persistence.mapper;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import com.bidmall.user.domain.model.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserPersistenceMapper {
+  User entityToDomain(UserEntity userEntity);
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
@@ -6,5 +6,10 @@ import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserPersistenceMapper {
+
+  // 로그인
   User entityToDomain(UserEntity userEntity);
+
+  // 회원가입
+  UserEntity domainToEntity(User user);
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/mapper/UserPersistenceMapper.java
@@ -7,9 +7,7 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface UserPersistenceMapper {
 
-  // 로그인
   User entityToDomain(UserEntity userEntity);
 
-  // 회원가입
   UserEntity domainToEntity(User user);
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.bidmall.user.adapter.out.persistence.repository;
+
+import com.bidmall.user.adapter.out.persistence.entity.UserEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+  Optional<UserEntity> findByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
-  Optional<UserEntity> findByAccountAndPasswordAndIsDeleted(String account, String password, boolean isDeleted);
+  Optional<UserEntity> findByAccountAndPasswordAndDeleted(String account, String password, boolean deleted);
 }

--- a/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/bidmall/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
-  Optional<UserEntity> findByAccountAndPassword(String account, String password);
+  Optional<UserEntity> findByAccountAndPasswordAndIsDeleted(String account, String password, boolean isDeleted);
 }

--- a/src/main/java/com/bidmall/user/application/auth/TokenManager.java
+++ b/src/main/java/com/bidmall/user/application/auth/TokenManager.java
@@ -1,0 +1,16 @@
+package com.bidmall.user.application.auth;
+
+import com.bidmall.user.domain.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenManager {
+
+  // note. 임시 코드 / 이후 삭제 및 변경 예정
+  public TokenResponse getToken(User user) {
+    return TokenResponse.builder()
+        .accessToken(user.getName())
+        .refreshToken(user.getName())
+        .build();
+  }
+}

--- a/src/main/java/com/bidmall/user/application/auth/TokenResponse.java
+++ b/src/main/java/com/bidmall/user/application/auth/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.application.auth;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+  private String accessToken;
+  private String refreshToken;
+
+}

--- a/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
+++ b/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
@@ -1,0 +1,12 @@
+package com.bidmall.user.application.mapper;
+
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.application.auth.TokenResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserApplicationMapper {
+
+  LoginResponse tokenResponseToLogin(TokenResponse tokenResponse);
+
+}

--- a/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
+++ b/src/main/java/com/bidmall/user/application/mapper/UserApplicationMapper.java
@@ -1,12 +1,17 @@
 package com.bidmall.user.application.mapper;
 
+import com.bidmall.user.adapter.in.web.dto.command.SignUpCommand;
 import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
 import com.bidmall.user.application.auth.TokenResponse;
+import com.bidmall.user.domain.model.User;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserApplicationMapper {
 
+  // 로그인
   LoginResponse tokenResponseToLogin(TokenResponse tokenResponse);
 
+  // 회원가입
+  User commandToUser(SignUpCommand signUpCommand);
 }

--- a/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
@@ -1,0 +1,12 @@
+package com.bidmall.user.application.port.in;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface UserUseCase {
+
+  LoginResponse login(LoginCommand loginCommand);
+
+}

--- a/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
@@ -1,6 +1,7 @@
 package com.bidmall.user.application.port.in;
 
 import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.command.SignUpCommand;
 import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
 import org.springframework.stereotype.Component;
 
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Component;
 public interface UserUseCase {
 
   LoginResponse login(LoginCommand loginCommand);
-
+  void signUp(SignUpCommand signUpCommand);
 }

--- a/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/bidmall/user/application/port/in/UserUseCase.java
@@ -10,4 +10,5 @@ public interface UserUseCase {
 
   LoginResponse login(LoginCommand loginCommand);
   void signUp(SignUpCommand signUpCommand);
+  void delete(Long userId);
 }

--- a/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
@@ -1,0 +1,7 @@
+package com.bidmall.user.application.port.out;
+
+import com.bidmall.user.domain.model.User;
+
+public interface UserRepositoryPort {
+  User findByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
@@ -5,4 +5,5 @@ import com.bidmall.user.domain.model.User;
 public interface UserRepositoryPort {
   User findActiveUserByAccountAndPassword(String account, String password);
   void save(User user);
+  User findById(Long id);
 }

--- a/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
@@ -3,6 +3,6 @@ package com.bidmall.user.application.port.out;
 import com.bidmall.user.domain.model.User;
 
 public interface UserRepositoryPort {
-  User findByAccountAndPassword(String account, String password);
+  User findActiveUserByAccountAndPassword(String account, String password);
   void save(User user);
 }

--- a/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/bidmall/user/application/port/out/UserRepositoryPort.java
@@ -4,4 +4,5 @@ import com.bidmall.user.domain.model.User;
 
 public interface UserRepositoryPort {
   User findByAccountAndPassword(String account, String password);
+  void save(User user);
 }

--- a/src/main/java/com/bidmall/user/application/service/UserService.java
+++ b/src/main/java/com/bidmall/user/application/service/UserService.java
@@ -1,0 +1,34 @@
+package com.bidmall.user.application.service;
+
+import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
+import com.bidmall.user.application.auth.TokenManager;
+import com.bidmall.user.application.auth.TokenResponse;
+import com.bidmall.user.application.mapper.UserApplicationMapper;
+import com.bidmall.user.application.port.in.UserUseCase;
+import com.bidmall.user.application.port.out.UserRepositoryPort;
+import com.bidmall.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserUseCase {
+
+  private final UserRepositoryPort userRepositoryPort;
+  private final UserApplicationMapper userMapper;
+  private final TokenManager tokenManager;
+
+  @Override
+  public LoginResponse login(LoginCommand loginCommand) {
+
+    String account = loginCommand.getAccount();
+    String password = loginCommand.getPassword();
+    User user = userRepositoryPort.findByAccountAndPassword(account, password);
+
+    TokenResponse response = tokenManager.getToken(user);
+
+    return userMapper.tokenResponseToLogin(response);
+  }
+
+}

--- a/src/main/java/com/bidmall/user/application/service/UserService.java
+++ b/src/main/java/com/bidmall/user/application/service/UserService.java
@@ -1,6 +1,7 @@
 package com.bidmall.user.application.service;
 
 import com.bidmall.user.adapter.in.web.dto.command.LoginCommand;
+import com.bidmall.user.adapter.in.web.dto.command.SignUpCommand;
 import com.bidmall.user.adapter.in.web.dto.response.LoginResponse;
 import com.bidmall.user.application.auth.TokenManager;
 import com.bidmall.user.application.auth.TokenResponse;
@@ -29,6 +30,13 @@ public class UserService implements UserUseCase {
     TokenResponse response = tokenManager.getToken(user);
 
     return userMapper.tokenResponseToLogin(response);
+  }
+
+  @Override
+  public void signUp(SignUpCommand signUpCommand) {
+
+    User user = userMapper.commandToUser(signUpCommand);
+    userRepositoryPort.save(user);
   }
 
 }

--- a/src/main/java/com/bidmall/user/application/service/UserService.java
+++ b/src/main/java/com/bidmall/user/application/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService implements UserUseCase {
 
     String account = loginCommand.getAccount();
     String password = loginCommand.getPassword();
-    User user = userRepositoryPort.findByAccountAndPassword(account, password);
+    User user = userRepositoryPort.findActiveUserByAccountAndPassword(account, password);
 
     TokenResponse response = tokenManager.getToken(user);
 

--- a/src/main/java/com/bidmall/user/application/service/UserService.java
+++ b/src/main/java/com/bidmall/user/application/service/UserService.java
@@ -39,4 +39,11 @@ public class UserService implements UserUseCase {
     userRepositoryPort.save(user);
   }
 
+  @Override
+  public void delete(Long userId) {
+    User user = userRepositoryPort.findById(userId);
+    user.delete();
+    userRepositoryPort.save(user);
+  }
+
 }

--- a/src/main/java/com/bidmall/user/domain/model/User.java
+++ b/src/main/java/com/bidmall/user/domain/model/User.java
@@ -1,0 +1,18 @@
+package com.bidmall.user.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class User {
+
+  private Long id;
+
+  private String account;
+
+  private String password;
+
+  private String name;
+
+}

--- a/src/main/java/com/bidmall/user/domain/model/User.java
+++ b/src/main/java/com/bidmall/user/domain/model/User.java
@@ -15,5 +15,9 @@ public class User {
 
   private String name;
 
-  private boolean isDeleted;
+  private boolean deleted;
+
+  public void delete() {
+    this.deleted = true;
+  }
 }

--- a/src/main/java/com/bidmall/user/domain/model/User.java
+++ b/src/main/java/com/bidmall/user/domain/model/User.java
@@ -15,4 +15,5 @@ public class User {
 
   private String name;
 
+  private boolean isDeleted;
 }

--- a/src/main/java/com/bidmall/user/exception/ErrorType.java
+++ b/src/main/java/com/bidmall/user/exception/ErrorType.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorType {
+  INVALID_CREDENTIALS("ID 혹은 PW가 잘못되었습니다.");
+
+  private final String message;
+
+  ErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/ErrorType.java
+++ b/src/main/java/com/bidmall/user/exception/ErrorType.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorType {
-  INVALID_CREDENTIALS("ID 혹은 PW가 잘못되었습니다.");
+  INVALID_CREDENTIALS("ID 혹은 PW가 잘못되었습니다."),
+  NOT_FOUND_USER("존재하지 않거나 접근 권한이 없는 회원입니다.");
 
   private final String message;
 

--- a/src/main/java/com/bidmall/user/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/bidmall/user/exception/InvalidCredentialsException.java
@@ -1,0 +1,18 @@
+package com.bidmall.user.exception;
+
+import com.bidmall.user.exception.type.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class InvalidCredentialsException extends BusinessException {
+
+  private final String code;
+  public InvalidCredentialsException() {
+    this(ErrorType.INVALID_CREDENTIALS.getMessage());
+  }
+
+  public InvalidCredentialsException(final String message) {
+    super(message);
+    this.code = ErrorType.INVALID_CREDENTIALS.name();
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/NotFoundUserException.java
+++ b/src/main/java/com/bidmall/user/exception/NotFoundUserException.java
@@ -1,0 +1,19 @@
+package com.bidmall.user.exception;
+
+import com.bidmall.user.exception.type.BusinessException;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundUserException extends BusinessException {
+
+  private final String code;
+  public NotFoundUserException() {
+    this(ErrorType.INVALID_CREDENTIALS.getMessage());
+  }
+
+  public NotFoundUserException(final String message) {
+    super(message);
+    this.code = ErrorType.INVALID_CREDENTIALS.name();
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/type/ApiErrorType.java
+++ b/src/main/java/com/bidmall/user/exception/type/ApiErrorType.java
@@ -1,0 +1,15 @@
+package com.bidmall.user.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ApiErrorType {
+
+  BAD_REQUEST("잘못된 요청입니다.");
+
+  private final String message;
+
+  ApiErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/bidmall/user/exception/type/BusinessException.java
+++ b/src/main/java/com/bidmall/user/exception/type/BusinessException.java
@@ -1,0 +1,14 @@
+package com.bidmall.user.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final String code;
+
+  public BusinessException(final String message) {
+    super(message);
+    this.code = ApiErrorType.BAD_REQUEST.name();
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,26 @@
+spring:
+  application:
+    name: user
+  cloud:
+    config:
+      enabled: false
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/bmUser
+    username: root
+    password: test
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   config:
     import: classpath:application-user-secret.yml
   profiles:
-    active: prod
+    active: local


### PR DESCRIPTION
[이전 작업](https://github.com/BidMall/user/pull/1)이 PR 진행 중인 관계로 커밋을 별도로 분리하지 않고 이어서 작업하였습니다. 
이전 작업 내용 중 변동 사항이 존재해 [ 로그인 -> 회원가입 -> 회원탈퇴 ] 순으로 Merge 예정입니다.

---

## 변동 사항
1. User 엔티티에 deleted 변수 추가
기존에는 isDeleted 라는 변수명으로 작업을 진행했으나, MapStruck 에서 is 가 붙은 변수명을 인식하는데 오류가 발생하는 것을 확인하여 작업 중간에 deleted 로 변경하였습니다.

2. Entity 내부 생성자 Builder -> Entity Builder 로 변경
해당 부분은 논의가 필요한 부분인 것같습니다.

현재 제가 이해하고 있는 헥사고날 아키텍쳐에서의 Entity는 Repository 와 통신만을 위한 객체로, 한 번 생성된 이후로 내부 값이 변동되지 않으며 이러한 Entity는 Domain 의 값을 매핑하여 형식으로 생성된다 이해했습니다. 때문에 모든 내부 값이 변동되는 작업은 Domain 에서 진행하는 것이 맞다고 생각하였습니다.

이러한 이유로 기존 ID 값을 제외한 내부 생성자 Builder 에서, 모든 변수 값을 포함한 Entity Builder 형식으로 변동하였습니다.
여기서 의문점은 Entity는 Domain 의 값을 받아오는 역할을 하고, MapStruck을 통해 매핑을 진행한다면 Builder 가 아닌 AllArgsConstructor 어노테이션만으로 충분한 것이 아닌가 하는 생각입니다.

3. 로그인시 delete 컬럼이 false 인, 즉, 삭제되지 않은 계정만 로그인 되도록 변경

---

## 이후 수정 사항

1. JWT 및 인증/인가 코드의 미작성으로, 현재 사용자의 정보를 가져오는 부분은 임의로 작성하였습니다.
2. User 엔티티의 account 컬럼에 중복된 값이 들어가지 않도록 유니크 키 설정이 필요합니다.
설정 이후, 회원가입시 아이디 중복 체크 API 를 따로 제공할 것인지, 회원가입 API 내부에서 중복 체크 후 예외 처리를 진행할 것인지 논의 필요할 것같습니다.